### PR TITLE
limit the scope of i in the fps const definition

### DIFF
--- a/html_ui/JS/debug.js
+++ b/html_ui/JS/debug.js
@@ -412,7 +412,7 @@ const fps = {
 
         // iterate samples to obtain the average
         let average = 0;
-        for (i = 0; i < this._sample_.length; i++) average += this._sample_[i];
+        for (let i = 0; i < this._sample_.length; i++) average += this._sample_[i];
 
         average = Math.round(average / this._sample_.length);
 


### PR DESCRIPTION
The way this sets up that for loop somehow lets i leak into the global environment.  This means you can mask errors from an undefined i that only appear when the devkit isn't installed.